### PR TITLE
Workflows

### DIFF
--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -76,7 +76,17 @@ jobs:
           journal_secret: ${{ secrets.JCON_SECRET }}
           issue_id: ${{ github.event.inputs.issue_id }}
           paper_path: ${{ steps.generate-files.outputs.paper_file_path}}
-      - name: Tweet
+      - name: Sleep for 300 seconds
+        run: sleep 300
+        shell: bash
+      - name: Citation.cff file info
+        uses: xuanxu/citation-file-action@main
+        with:
+          citation_file_path: ${{ steps.generate-files.outputs.citation_file_path}}
+          issue_id: ${{ github.event.inputs.issue_id }}
+          reviews_repo: JuliaCon/proceedings-review
+          gh_token: ${{ secrets.BOT_TOKEN }}
+      - name: Post to social media
         uses: xuanxu/acceptance-tweet-action@main
         with:
           journal_name: "JCON"
@@ -86,6 +96,10 @@ jobs:
           twitter_consumer_secret: ${{ secrets.TWITTER_CONSUMER_SECRET }}
           twitter_access_token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
           twitter_access_token_secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+          twitter_user: ${{ secrets.TWITTER_USER }}
+          mastodon_access_token: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+          mastodon_instance_url: ${{ secrets.MASTODON_INSTANCE_URL }}
+          mastodon_user: ${{ secrets.MASTODON_USER }}
           reviews_repo: JuliaCon/proceedings-review
           issue_id: ${{ github.event.inputs.issue_id }}
           gh_token: ${{ secrets.BOT_TOKEN }}
@@ -97,7 +111,7 @@ jobs:
           Here's what you must now do:
 
           0. Check final PDF and Crossref metadata that was deposited :point_right: ${{steps.pull-request.outputs.pr_url}}
-          1. Wait a couple of minutes, then verify that the paper DOI resolves [https://doi.org/${{steps.oj-deposit.outputs.paper_doi}}](https://doi.org/${{steps.oj-deposit.outputs.paper_doi}})
+          1. Wait five minutes, then verify that the paper DOI resolves [https://doi.org/${{steps.oj-deposit.outputs.paper_doi}}](https://doi.org/${{steps.oj-deposit.outputs.paper_doi}})
           2. If everything looks good, then close this review issue.
           3. Party like you just published a paper! 🎉🌈🦄💃👻🤘
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,28 @@
+name: Repository and paper info
+on:
+  workflow_dispatch:
+    inputs:
+      repository_url:
+        description: 'URL of the repository where the paper file is: org/reponame'
+        required: true
+      branch:
+        description: 'Git branch with the paper file'
+        required: false
+        default: ""
+      issue_id:
+        description: 'The issue number of the submission to post the results'
+        required: true
+env:
+  GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+  GH_REPO: JuliaCon/proceedings-review
+jobs:
+  run-analysis:
+    name: ${{ format('Repository and paper analysis for issue {0}', github.event.inputs.issue_id) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository and paper analysis
+        uses: openjournals/gh-action-repo-checks@main
+        with:
+          repository_url: ${{ github.event.inputs.repository_url }}
+          branch: ${{ github.event.inputs.branch }}
+          issue_id: ${{ github.event.inputs.issue_id }}

--- a/.github/workflows/compile-pdf.yml
+++ b/.github/workflows/compile-pdf.yml
@@ -1,0 +1,25 @@
+name: Compile paper
+on:
+  pull_request:
+jobs:
+  compile-paper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2.2
+          bundler-cache: true
+      - name: preprocessing
+        run: |
+          cd paper
+          ruby prep.rb
+      - name: generate pdf
+        uses: xu-cheng/texlive-action/full@v1
+        with:
+          run: |
+            cd paper
+            latexmk -c
+            latexmk -bibtex -pdf paper.tex
+            latexmk -c

--- a/.github/workflows/compile-pdf.yml
+++ b/.github/workflows/compile-pdf.yml
@@ -1,6 +1,6 @@
 name: Compile paper
 on:
-  pull_request:
+  workflow_dispatch:
 jobs:
   compile-paper:
     runs-on: ubuntu-latest

--- a/.github/workflows/draft-paper.yml
+++ b/.github/workflows/draft-paper.yml
@@ -6,7 +6,7 @@ on:
         description: 'URL of the repository containing the paper file'
         required: true
       branch:
-        description: 'Git branch where the paper Markdown file is'
+        description: 'Git branch where the paper source file is'
         required: false
       issue_id:
         description: 'The issue number of the submission in the JCON reviews repo'

--- a/.github/workflows/preprint.yml
+++ b/.github/workflows/preprint.yml
@@ -1,0 +1,38 @@
+name: Preprint
+on:
+  workflow_dispatch:
+    inputs:
+      repository_url:
+        description: 'URL of the repository containing the paper file'
+        required: true
+      branch:
+        description: 'Git branch where the paper source file is'
+        required: false
+      issue_id:
+        description: 'The issue number of the submission in the JCON reviews repo'
+        required: true
+jobs:
+  latex-preprint-generation:
+    name: ${{ format('Preprint file for issue {0}', github.event.inputs.issue_id) }}
+    runs-on: ubuntu-latest
+    env:
+      GH_ACCESS_TOKEN: ${{ secrets.BOT_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+      GH_REPO: JuliaCon/proceedings-review
+    steps:
+      - name: Generate preprint file
+        id: generate-preprint
+        uses: xuanxu/preprint-action@main
+        with:
+          repository_url: ${{ github.event.inputs.repository_url }}
+          branch: ${{ github.event.inputs.branch }}
+          issue_id: ${{ github.event.inputs.issue_id }}
+          journal: jcon
+      - name: Reply message
+        if: ${{ success() }}
+        run: |
+          gh issue comment ${{ github.event.inputs.issue_id }} --body ":page_facing_up: Preprint file created: [Find it here in the Artifacts list](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) :page_facing_up: "
+      - name: Error message
+        if: ${{ failure() }}
+        run: |
+          gh issue comment ${{ github.event.inputs.issue_id }} --body ":warning: [An error happened when generating the LaTeX preprint file](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?check_suite_focus=true). ${{ env.CUSTOM_ERROR }}"

--- a/.github/workflows/reaccept.yml
+++ b/.github/workflows/reaccept.yml
@@ -12,7 +12,7 @@ on:
         description: 'The issue number of the submission'
         required: true
 jobs:
-  acceptance-and-publishing:
+  reacceptance-and-publishing:
     name: ${{ format('Updating accepted paper from issue {0}', github.event.inputs.issue_id) }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/recommend-acceptance.yml
+++ b/.github/workflows/recommend-acceptance.yml
@@ -24,7 +24,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
       GH_REPO: JuliaCon/proceedings-review
       ISSUE_ID: ${{ github.event.inputs.issue_id }}
-      DEFAULT_ERROR: ":warning: [Error prepararing paper acceptance](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?check_suite_focus=true)."
+      DEFAULT_ERROR: ":warning: [Error preparing paper acceptance](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}?check_suite_focus=true)."
     steps:
       - name: Compile Paper
         id: generate-files
@@ -66,9 +66,9 @@ jobs:
         run: |
           gh issue comment ${{ github.event.inputs.issue_id }} --body ":wave: @JuliaCon/jcon-eics, this paper is ready to be accepted and published.
 
-          Check final proof :point_right: ${{ steps.open-pr.outputs.pr_url}}
+          Check final proof :point_right::page_facing_up: [Download article](${{ steps.upload-files.outputs.pdf_download_url }})
 
-          If the paper PDF and the deposit XML files look good in ${{ steps.open-pr.outputs.pr_url}}, then you can now move forward with accepting the submission by compiling again with the command \`@editorialbot accept\`"
+          If the paper PDF and the deposit XML files look good in ${{ steps.open-pr.outputs.pr_url }}, then you can now move forward with accepting the submission by compiling again with the command \`@editorialbot accept\`"
       - name: Labeling
         if: ${{ success() && github.event.inputs.add_labels != '' }}
         run: gh issue edit ${{ github.event.inputs.issue_id }} --add-label ${{ github.event.inputs.add_labels }}

--- a/.github/workflows/references.yml
+++ b/.github/workflows/references.yml
@@ -1,0 +1,28 @@
+name: Check bibtex references
+on:
+  workflow_dispatch:
+    inputs:
+      repository_url:
+        description: 'URL of the repository where the paper file is: org/reponame'
+        required: true
+      branch:
+        description: 'Git branch with the paper file'
+        required: false
+        default: ""
+      issue_id:
+        description: 'The issue number of the submission to post the results'
+        required: true
+env:
+  GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+  GH_REPO: JuliaCon/proceedings-review
+jobs:
+  run-doi-validation:
+    name: ${{ format('DOIs validation for issue {0}', github.event.inputs.issue_id) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: DOIs validation
+        uses: openjournals/gh-action-check-references@main
+        with:
+          repository_url: ${{ github.event.inputs.repository_url }}
+          branch: ${{ github.event.inputs.branch }}
+          issue_id: ${{ github.event.inputs.issue_id }}

--- a/.github/workflows/retract.yml
+++ b/.github/workflows/retract.yml
@@ -1,0 +1,34 @@
+name: Retract paper
+on:
+  workflow_dispatch:
+    inputs:
+      issue_id:
+        description: 'The issue number of the retracted paper review'
+        required: true
+      retraction_notice_url:
+        description: 'URL for the markdown file of the retraction notice'
+        required: true
+      mode:
+        description: Set the compiled retraction notice as a draft or as a final published paper. Posible values are 'draft' or 'final'.
+        required: false
+        default: draft
+jobs:
+  retraction-notice:
+    name: ${{ format('Retracting paper in issue {0}', github.event.inputs.issue_id) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate retraction notice
+        id: generate-retraction
+        uses: xuanxu/retraction-action@main
+        with:
+          retraction_notice_url: ${{ github.event.inputs.retraction_notice_url }}
+          issue_id: ${{ github.event.inputs.issue_id }}
+          journal: jcon
+          papers_repo: JuliaCon/proceedings-papers
+          papers_repo_main_branch: master
+          branch_prefix: jcon
+          github_bot_token: ${{ secrets.BOT_TOKEN }}
+          journal_secret: ${{ secrets.JCON_SECRET }}
+          crossref_username: ${{ secrets.CROSSREF_USERNAME }}
+          crossref_password: ${{ secrets.CROSSREF_PASSWORD }}
+          mode: ${{ github.event.inputs.mode }}


### PR DESCRIPTION
This PR adds all the workflows needed to use the openjournals gh-actions to be triggered by the editorial bot. 