### PR TITLE
Fix co-author name

### DIFF
--- a/jcon.00138/10.21105.jcon.00138.crossref.xml
+++ b/jcon.00138/10.21105.jcon.00138.crossref.xml
@@ -47,7 +47,7 @@
           </person_name>
           <person_name sequence="additional" contributor_role="author">
             <given_name>Ludovic</given_name>
-            <surname>R\'ass</surname>
+            <surname>Räss</surname>
             <ORCID>http://orcid.org/0000-0002-1136-899X</ORCID>
           </person_name>
         </contributors>


### PR DESCRIPTION
This PR fix the issue with the last name of the co-author containing a badly rendered letter `ä`.